### PR TITLE
Debian9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ mailcow
 
 mailcow is a mail server suite based on Dovecot, Postfix and other open source software, that provides a modern web UI for user/server administration.
 
-mailcow supports **Debian 8 (Jessie), Ubuntu LTS 14.04 (Trusty Tahr) and Ubuntu LTS 16.04 (Xenial Xerus)**
+mailcow supports **Debian 8 (Jessie), DEBIAN 9 (Stretch), Ubuntu LTS 14.04 (Trusty Tahr) and Ubuntu LTS 16.04 (Xenial Xerus)**
 
 [Everybody loves screenshots (v0.14)](http://imgur.com/a/lWX2V)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ mailcow
 
 mailcow is a mail server suite based on Dovecot, Postfix and other open source software, that provides a modern web UI for user/server administration.
 
-mailcow supports **Debian 8 (Jessie), DEBIAN 9 (Stretch), Ubuntu LTS 14.04 (Trusty Tahr) and Ubuntu LTS 16.04 (Xenial Xerus)**
+mailcow supports **Debian 8 (Jessie), Debian 9 (Stretch), Ubuntu LTS 14.04 (Trusty Tahr) and Ubuntu LTS 16.04 (Xenial Xerus)**
 
 [Everybody loves screenshots (v0.14)](http://imgur.com/a/lWX2V)
 

--- a/includes/functions.sh
+++ b/includes/functions.sh
@@ -200,9 +200,6 @@ installtask() {
 					fi
 					OPENJDK="openjdk-7"
 					JETTY_NAME="jetty8"
-				else
-					echo "$(redb [ERR]) - Your Debian distribution is currently not supported"
-					exit 1
 				elif [[ ${dist_codename} == "stretch" ]]; then
 					#Debian 9 will not start Postfix or Dovecot when SSLv2 parameter is used
 					sed -i 's/!SSLv2, //g' ../postfix/main.cf

--- a/includes/functions.sh
+++ b/includes/functions.sh
@@ -203,8 +203,8 @@ installtask() {
 					JETTY_NAME="jetty8"
 				elif [[ ${dist_codename} == "stretch" ]]; then
 					#Debian 9 will not start Postfix or Dovecot when SSLv2 parameter is used. There is no support for php-mail-mimedecode
-					sed -i 's/!SSLv2, //g' ../postfix/main.cf
-					sed -i 's/!SSLv2//g' ../dovecot/conf/dovecot.conf
+					sed -i 's/!SSLv2, //g' ./postfix/conf/main.cf
+					sed -i 's/!SSLv2//g' ./dovecot/conf/dovecot.conf
 					PHPMAILMIMEDECODE=""
 					if [[ ${httpd_platform} == "apache2" ]]; then
 						WEBSERVER_BACKEND="apache2 apache2-utils libapache2-mod-${PHP}"

--- a/includes/functions.sh
+++ b/includes/functions.sh
@@ -257,6 +257,10 @@ installtask() {
 					DATABASE_BACKEND="mariadb-client mariadb-server"
 				else
 					DATABASE_BACKEND="mysql-client mysql-server"
+					# In Debian 9 the mysql-client package was renamed to default-mysql-client
+					if [[ ${dist_codename} == "stretch" ]]; then
+						DATABASE_BACKEND="default-mysql-client mysql-server"
+					fi
 				fi
 			else
 				DATABASE_BACKEND=""

--- a/includes/functions.sh
+++ b/includes/functions.sh
@@ -204,6 +204,21 @@ installtask() {
 					echo "$(redb [ERR]) - Your Debian distribution is currently not supported"
 					exit 1
 				fi
+				if [[ ${dist_codename} == "stretch" ]]; then
+					#Debian 9 will not start Postfix or Dovecot when SSLv2 parameter is used
+					sed -i 's/!SSLv2, //g' ../postfix/main.cf
+					sed -i 's/!SSLv2//g' ../dovecot/conf/dovecot.conf
+					if [[ ${httpd_platform} == "apache2" ]]; then
+						WEBSERVER_BACKEND="apache2 apache2-utils libapache2-mod-${PHP}"
+					else
+						WEBSERVER_BACKEND="nginx-extras ${PHP}-fpm"
+					fi
+					OPENJDK="openjdk-8"
+					JETTY_NAME="jetty9"
+				else
+					echo "$(redb [ERR]) - Your Debian distribution is currently not supported"
+					exit 1
+				fi
 			elif [[ ${dist_id} == "Ubuntu" ]]; then
 				if [[ ${dist_codename} == "trusty" ]]; then
 					if [[ ${httpd_platform} == "apache2" ]]; then
@@ -254,6 +269,10 @@ ${PHP}-intl ${PHP}-xsl ${PHP}-mcrypt ${PHP}-mysql libawl-php ${PHP}-xmlrpc ${DAT
 postfix postfix-mysql postfix-pcre postgrey pflogsumm spamassassin spamc sa-compile libdbd-mysql-perl opendkim opendkim-tools clamav-daemon \
 python-magic liblockfile-simple-perl libdbi-perl libmime-base64-urlsafe-perl libtest-tempdir-perl liblogger-syslog-perl \
 ${OPENJDK}-jre-headless libcurl4-openssl-dev libexpat1-dev solr-jetty > /dev/null
+			#Debian 9 does not support "php-mail-mimedecode". Push package out of array
+			if [[ ${dist_codename} == "stretch" ]]; then
+				DEBIAN_FRONTEND=(${DEBIAN_FRONTEND[@]/php-mail-mimedecode})
+			fi
 			if [ "$?" -ne "0" ]; then
 				echo "$(redb [ERR]) - Package installation failed:"
 				tail -n 20 /var/log/dpkg.log

--- a/includes/functions.sh
+++ b/includes/functions.sh
@@ -203,8 +203,7 @@ installtask() {
 				else
 					echo "$(redb [ERR]) - Your Debian distribution is currently not supported"
 					exit 1
-				fi
-				if [[ ${dist_codename} == "stretch" ]]; then
+				elif [[ ${dist_codename} == "stretch" ]]; then
 					#Debian 9 will not start Postfix or Dovecot when SSLv2 parameter is used
 					sed -i 's/!SSLv2, //g' ../postfix/main.cf
 					sed -i 's/!SSLv2//g' ../dovecot/conf/dovecot.conf


### PR DESCRIPTION
Now there is tested support for Debian 9. The test was made with following settings:

- apache2
- mysql

Things that have changed:

- Added "stretch" to ${dist_codename} chain
- In chain remove package "php-mail-mimedecode" (not supported)
- Changed names of mysql-server and mysql-client
- Removed "SSLv2"-Parameters